### PR TITLE
Move to trait_get, keep get as alias

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -1133,7 +1133,7 @@ class CommandLine(BaseInterface):
         metadata = dict(name_source=lambda t: t is not None)
         traits = self.inputs.traits(**metadata)
         if traits:
-            outputs = self.output_spec().get()
+            outputs = self.output_spec().trait_get()
             for name, trait_spec in list(traits.items()):
                 out_name = name
                 if trait_spec.output_name is not None:
@@ -1237,7 +1237,7 @@ class SEMLikeCommandLine(CommandLine):
     """
 
     def _list_outputs(self):
-        outputs = self.output_spec().get()
+        outputs = self.output_spec().trait_get()
         return self._outputs_from_inputs(outputs)
 
     def _outputs_from_inputs(self, outputs):

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -169,7 +169,7 @@ class BaseTraitedSpec(traits.HasTraits):
         any traits. The dictionary does not contain any attributes that
         were Undefined
         """
-        out = super(BaseTraitedSpec, self).get(**kwargs)
+        out = super(BaseTraitedSpec, self).trait_get(**kwargs)
         out = self._clean_container(out, skipundefined=True)
         return out
 
@@ -237,7 +237,7 @@ class BaseTraitedSpec(traits.HasTraits):
 
         list_withhash = []
         list_nofilename = []
-        for name, val in sorted(self.get().items()):
+        for name, val in sorted(self.trait_get().items()):
             if not isdefined(val) or self.has_metadata(name, "nohash", True):
                 # skip undefined traits and traits with nohash=True
                 continue
@@ -342,7 +342,7 @@ class DynamicTraitedSpec(BaseTraitedSpec):
         id_self = id(self)
         if id_self in memo:
             return memo[id_self]
-        dup_dict = deepcopy(self.get(), memo)
+        dup_dict = deepcopy(self.trait_get(), memo)
         # access all keys
         for key in self.copyable_trait_names():
             if key in self.__dict__.keys():

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -150,18 +150,17 @@ class BaseTraitedSpec(traits.HasTraits):
                             '%s' % trait_spec.new_name: new
                         })
 
-    def get(self, **kwargs):
+    def trait_get(self, **kwargs):
         """ Returns traited class as a dict
 
         Augments the trait get function to return a dictionary without
         notification handles
         """
-        try:
-            out = super(BaseTraitedSpec, self).trait_get(**kwargs)
-        except AttributeError:  # deprecated old get
-            out = super(BaseTraitedSpec, self).get(**kwargs)
+        out = super(BaseTraitedSpec, self).trait_get(**kwargs)
         out = self._clean_container(out, Undefined)
         return out
+
+    get = trait_get
 
     def get_traitsfree(self, **kwargs):
         """ Returns traited class as a dict

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -531,7 +531,7 @@ class Node(EngineBase):
             else:
                 output_name = info[1]
                 try:
-                    output_value = results.outputs.get()[output_name]
+                    output_value = results.outputs.trait_get()[output_name]
                 except TypeError:
                     output_value = results.outputs.dictcopy()[output_name]
             logger.debug('output: %s', output_name)
@@ -678,7 +678,7 @@ class Node(EngineBase):
             makedirs(outdir, exist_ok=True)
 
         for info in self._interface._get_filecopy_info():
-            files = self.inputs.get().get(info['key'])
+            files = self.inputs.trait_get().get(info['key'])
             if not isdefined(files) or not files:
                 continue
 
@@ -1084,7 +1084,7 @@ class MapNode(Node):
     @property
     def outputs(self):
         if self._interface._outputs():
-            return Bunch(self._interface._outputs().get())
+            return Bunch(self._interface._outputs().trait_get())
 
     def _make_nodes(self, cwd=None):
         if cwd is None:
@@ -1109,7 +1109,7 @@ class MapNode(Node):
                 name=nodename)
             node.plugin_args = self.plugin_args
             node.interface.inputs.trait_set(
-                **deepcopy(self._interface.inputs.get()))
+                **deepcopy(self._interface.inputs.trait_get()))
             node.interface.resource_monitor = self._interface.resource_monitor
             for field in self.iterfield:
                 if self.nested:
@@ -1153,7 +1153,7 @@ class MapNode(Node):
                     if not isdefined(values):
                         values = []
                     if nresult and nresult.outputs:
-                        values.insert(i, nresult.outputs.get()[key])
+                        values.insert(i, nresult.outputs.trait_get()[key])
                     else:
                         values.insert(i, None)
                     defined_vals = [isdefined(val) for val in values]
@@ -1201,7 +1201,7 @@ class MapNode(Node):
         return len(filename_to_list(getattr(self.inputs, self.iterfield[0])))
 
     def _get_inputs(self):
-        old_inputs = self._inputs.get()
+        old_inputs = self._inputs.trait_get()
         self._inputs = self._create_dynamic_traits(
             self._interface.inputs, fields=self.iterfield)
         self._inputs.trait_set(**old_inputs)

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -532,7 +532,7 @@ class Node(EngineBase):
                 output_name = info[1]
                 try:
                     output_value = results.outputs.trait_get()[output_name]
-                except TypeError:
+                except AttributeError:
                     output_value = results.outputs.dictcopy()[output_name]
             logger.debug('output: %s', output_name)
             try:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -142,7 +142,7 @@ def write_report(node, report_type=None, is_mapnode=False):
                 ['Hierarchy : %s' % node.fullname,
                  'Exec ID : %s' % node._id]),
             write_rst_header('Original Inputs', level=1),
-            write_rst_dict(node.inputs.get()),
+            write_rst_dict(node.inputs.trait_get()),
         ]
         with open(report_file, 'wt') as fp:
             fp.write('\n'.join(lines))
@@ -150,7 +150,7 @@ def write_report(node, report_type=None, is_mapnode=False):
 
     lines = [
         write_rst_header('Execution Inputs', level=1),
-        write_rst_dict(node.inputs.get()),
+        write_rst_dict(node.inputs.trait_get()),
     ]
 
     result = node.result  # Locally cache result
@@ -166,7 +166,7 @@ def write_report(node, report_type=None, is_mapnode=False):
     if isinstance(outputs, Bunch):
         lines.append(write_rst_dict(outputs.dictcopy()))
     elif outputs:
-        lines.append(write_rst_dict(outputs.get()))
+        lines.append(write_rst_dict(outputs.trait_get()))
 
     if is_mapnode:
         lines.append(write_rst_header('Subnode reports', level=1))
@@ -238,7 +238,7 @@ def save_resultfile(result, cwd, name):
     resultsfile = os.path.join(cwd, 'result_%s.pklz' % name)
     if result.outputs:
         try:
-            outputs = result.outputs.get()
+            outputs = result.outputs.trait_get()
         except TypeError:
             outputs = result.outputs.dictcopy()  # outputs was a bunch
         result.outputs.set(**modify_paths(outputs, relative=True, basedir=cwd))
@@ -293,7 +293,7 @@ def load_resultfile(path, name):
         else:
             if result.outputs:
                 try:
-                    outputs = result.outputs.get()
+                    outputs = result.outputs.trait_get()
                 except TypeError:
                     outputs = result.outputs.dictcopy()  # outputs == Bunch
                 try:
@@ -1391,19 +1391,19 @@ def clean_working_directory(outputs,
     """
     if not outputs:
         return
-    outputs_to_keep = list(outputs.get().keys())
+    outputs_to_keep = list(outputs.trait_get().keys())
     if needed_outputs and \
        str2bool(config['execution']['remove_unnecessary_outputs']):
         outputs_to_keep = needed_outputs
     # build a list of needed files
     output_files = []
-    outputdict = outputs.get()
+    outputdict = outputs.trait_get()
     for output in outputs_to_keep:
         output_files.extend(walk_outputs(outputdict[output]))
     needed_files = [path for path, type in output_files if type == 'f']
     if str2bool(config['execution']['keep_inputs']):
         input_files = []
-        inputdict = inputs.get()
+        inputdict = inputs.trait_get()
         input_files.extend(walk_outputs(inputdict))
         needed_files += [path for path, type in input_files if type == 'f']
     for extra in [
@@ -1435,7 +1435,7 @@ def clean_working_directory(outputs,
     else:
         if not str2bool(config['execution']['keep_inputs']):
             input_files = []
-            inputdict = inputs.get()
+            inputdict = inputs.trait_get()
             input_files.extend(walk_outputs(inputdict))
             input_files = [path for path, type in input_files if type == 'f']
             for f in walk_files(cwd):

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -239,7 +239,7 @@ def save_resultfile(result, cwd, name):
     if result.outputs:
         try:
             outputs = result.outputs.trait_get()
-        except TypeError:
+        except AttributeError:
             outputs = result.outputs.dictcopy()  # outputs was a bunch
         result.outputs.set(**modify_paths(outputs, relative=True, basedir=cwd))
 
@@ -294,7 +294,7 @@ def load_resultfile(path, name):
             if result.outputs:
                 try:
                     outputs = result.outputs.trait_get()
-                except TypeError:
+                except AttributeError:
                     outputs = result.outputs.dictcopy()  # outputs == Bunch
                 try:
                     result.outputs.set(


### PR DESCRIPTION
Suggested update to nipy/nipype#2534 in line with Satra's comments. Also moved to directly call `trait_get` in core modules `nipype.pipeline` and `nipype.interfaces.base`.

Feel free to close if you disagree with the approach.